### PR TITLE
fix(plugin): add cclab: prefix to skill names in SKILL.md frontmatter

### DIFF
--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: check
+name: cclab:check
 description: Validate the current exercise and report pass/fail. Updates progress on success. Use when the user says "check", "validate", "verify", "am I done?", "did I pass?", or wants to test their work.
 ---
 

--- a/.claude/skills/help/SKILL.md
+++ b/.claude/skills/help/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: help
+name: cclab:help
 description: Show a summary of all available cclab skills with commands, descriptions, and quick examples. Use when the user says "help", "commands", "what can I do", "how does cclab work", or wants to see available skills.
 ---
 

--- a/.claude/skills/hint/SKILL.md
+++ b/.claude/skills/hint/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: hint
+name: cclab:hint
 description: Show a progressive hint for the current exercise. Each call reveals a more specific hint (up to 3 levels). Use when the user says "hint", "help me", "I'm stuck", "give me a clue", or needs guidance on the current exercise.
 ---
 

--- a/.claude/skills/reset/SKILL.md
+++ b/.claude/skills/reset/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: reset
+name: cclab:reset
 description: Reset the current exercise by restoring its workspace and clearing hint progress. Use when the user says "reset", "restart", "start over", "redo", or wants to redo the current exercise from scratch.
 ---
 

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: setup
+name: cclab:setup
 description: Configure permissions for a smoother cclab learning experience. Adds allow rules so Claude can read/write exercise files without repeated prompts. Use when the user says "setup", "configure permissions", "stop asking me", or wants to reduce permission prompts.
 ---
 

--- a/.claude/skills/start/SKILL.md
+++ b/.claude/skills/start/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: start
+name: cclab:start
 description: Begin or resume the cclab learning experience. Loads the current exercise, runs setup, and presents instructions. Use when the user says "start", "begin", "resume", "next exercise", or wants to start learning Claude Code.
 ---
 

--- a/.claude/skills/status/SKILL.md
+++ b/.claude/skills/status/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: status
+name: cclab:status
 description: Show progress dashboard with track overview, completion percentage, and current position. Use when the user says "status", "progress", "how far", "dashboard", or wants to see their learning progress.
 ---
 


### PR DESCRIPTION
## Summary
- Added `cclab:` namespace prefix to the `name` field in all 7 learner-facing SKILL.md frontmatter files
- Aligns skill names with how exercises reference them (e.g., `/cclab:start` instead of `/start`)
- Prevents potential conflicts with other plugins

Closes #1

## Test plan
- [x] Verify `/cclab:start`, `/cclab:check`, `/cclab:hint`, `/cclab:status`, `/cclab:reset`, `/cclab:setup`, `/cclab:help` all trigger correctly
- [x] Confirm exercise instructions still match the skill names

🤖 Generated with [Claude Code](https://claude.com/claude-code)